### PR TITLE
Dynamic Exit Point for Maze Generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "trivia-maze",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/vite-project/src/models/MazeGenerator.ts
+++ b/vite-project/src/models/MazeGenerator.ts
@@ -4,14 +4,15 @@
  * This class is responsible for handling logic related to generating a maze for the game.
  * The maze is generated using a recursive backtracking algorithm (Prim's algorithm).
  * 
- * @author Ethan Moore
- * @version 1.0
+ * @author Ethan Moore (handkrchief)
+ * @version November 11, 2024
 */
 export default class MazeGenerator{
 
 
 /**
- * Generates a maze of a given size
+ * Generates a maze of a given size sets the starting point to the beginning
+ * of the array, and sets the end point as the last explored space.
  * 
  * @param {number} theSize - The size of the maze
  * @returns {number[][]} - A 2D array representing the maze
@@ -24,7 +25,8 @@ public mazeGeneration(theSize:number):number[][]{
     let neighbors:number[][] = [];
     this.addNeighboringWalls({theRow:0, theCol:0, theNeighbors:neighbors, theSize});
 
-    
+    let myLastVisited = [0, 0];
+
     while(neighbors.length > 0){
         let randomNumber: number = Math.floor(Math.random() * neighbors.length);
         let myWall: number[] = neighbors[randomNumber];
@@ -36,10 +38,11 @@ public mazeGeneration(theSize:number):number[][]{
         if(this.canCarve({theMaze, theRow, theCol})){
             theMaze[theRow][theCol] = 1;
             this.addNeighboringWalls({theRow, theCol, theNeighbors:neighbors, theSize});
+            myLastVisited = [theRow, theCol];
         }
     }
     theMaze[0][0] = 5;
-    theMaze[theSize - 1][theSize - 1] = 9;
+    theMaze[myLastVisited[0]][myLastVisited[1]] = 9;
     this.generateBonus({theMaze, theSize});
     return theMaze;
 }


### PR DESCRIPTION
# Description

The PR updates the maze generation logic to dynamically set the exit point at the last visited cell rather than hardcoding it as the bottom-right cell. Originally I was trying to keep the bottom right as the exit point to have the maze be as long as it could be, but that doesn't seem a viable option.  The new way ensures that there will always be a valid path to the exit improving the reliability of the generation.

# Changes Made

- Added a myLastVisited variable to track the last cell successfully carved into the maze.
- Updated the mazeGeneration method to set the exit point at myLastVisited after the loop completes.
- Removed the hardcoded assignment to the exit point.